### PR TITLE
build for 64bit too

### DIFF
--- a/libmagic/build.gradle
+++ b/libmagic/build.gradle
@@ -9,7 +9,7 @@ android {
         versionCode 2
         versionName "1.1.1"
         ndk {
-            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86'
+            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86-64'
         }
         externalNativeBuild {
             cmake {

--- a/libmagic/build.gradle
+++ b/libmagic/build.gradle
@@ -9,7 +9,7 @@ android {
         versionCode 2
         versionName "1.1.1"
         ndk {
-            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86-64'
+            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
         }
         externalNativeBuild {
             cmake {


### PR DESCRIPTION
64bit is required for new apps now: https://android-developers.googleblog.com/2019/01/get-your-apps-ready-for-64-bit.html