### PR TITLE
gitignore .cxx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /build
 /captures
 .externalNativeBuild
+.cxx/


### PR DESCRIPTION
used by latest NDK